### PR TITLE
Correct README overdraft flag wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Or better yet:
     end
 
 By default accounts are prevented from having a negative balance, but you can
-pass `overdraft_enabled: false` to allow it:
+pass `overdraft_enabled: true` to allow it:
 
     DebitCredit::AssetAccount.create ..., overdraft_enabled: true
 


### PR DESCRIPTION
## Summary

The README prose contradicted both its own example and the model behavior for the overdraft flag.

- Prose said: `pass `overdraft_enabled: false` to allow it`
- Example directly below used `overdraft_enabled: true` (correct)
- `DebitCredit::Account` validates with `validate :prevent_overdraft, unless: :overdraft_enabled?`, so `true` is what permits a negative balance.

## Change

One-word correction in `README.md` only: `overdraft_enabled: false` → `overdraft_enabled: true` in the prose sentence. No code, schema, test, or fixture changes.

Line 233 (`accounts with `overdraft_enabled: false``) is left untouched — it correctly describes the inverse-entry overdraft bypass (`entry.rb` sets `ignore_overdraft: true` on inverse entries), a separate mechanism from the `overdraft_enabled?` opt-in.

## Verification

```sh
$ git diff --name-only
README.md
$ git diff
diff --git a/README.md b/README.md
@@ -165,7 +165,7 @@ ...
-pass `overdraft_enabled: false` to allow it:
+pass `overdraft_enabled: true` to allow it:
```

Prose and example now agree with `DebitCredit::Account#prevent_overdraft` (`app/models/debit_credit/account.rb:8`) and `account_test.rb:169` ("allows negative balance when overdraft_enabled? is true").

No merge, tag, release, or publish performed.